### PR TITLE
Implement CRUD operations for Genre entity in GenresService

### DIFF
--- a/src/genres/genres.service.ts
+++ b/src/genres/genres.service.ts
@@ -1,27 +1,49 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateGenreDto } from './dto/create-genre.dto';
 import { UpdateGenreDto } from './dto/update-genre.dto';
 import { Genre } from './entities/genre.entity';
 
 @Injectable()
 export class GenresService {
+  constructor(
+    @InjectRepository(Genre)
+    private readonly genreRepository: Repository<Genre>,
+  ) {}
+
   async create(createGenreDto: CreateGenreDto): Promise<Genre> {
-    return null;
+    const genre = this.genreRepository.create(createGenreDto);
+    return this.genreRepository.save(genre);
   }
 
   async findAll(): Promise<Genre[]> {
-    return null;
+    return this.genreRepository.find();
   }
 
   async findOne(id: number): Promise<Genre> {
-    return null;
+    const genre = await this.genreRepository.findOneBy({ id });
+    if (!genre) {
+      throw new NotFoundException(`Genre with ID ${id} not found`);
+    }
+    return genre;
   }
 
   async update(id: number, updateGenreDto: UpdateGenreDto): Promise<void> {
-    return null;
+    const genre = await this.genreRepository.preload({
+      id,
+      ...updateGenreDto,
+    });
+    if (!genre) {
+      throw new NotFoundException(`Genre with ID ${id} not found`);
+    }
+    await this.genreRepository.save(genre);
   }
 
   async remove(id: number): Promise<void> {
-    return null;
+    const result = await this.genreRepository.delete(id);
+    if (result.affected === 0) {
+      throw new NotFoundException(`Genre with ID ${id} not found`);
+    }
   }
 }


### PR DESCRIPTION
closes #1 

### Summary

This pull request implements the CRUD operations for the `Genre` entity in the `GenresService`. The service now provides methods to create, retrieve, update, and delete genres, utilizing the TypeORM repository for database interactions. It also includes error handling to manage scenarios where a genre is not found.

### Changes Made

- **Create Method**: Implements the creation of a new genre by using `this.genreRepository.create` and `this.genreRepository.save`.
- **FindAll Method**: Retrieves all genres from the database.
- **FindOne Method**: Fetches a genre by ID, throwing a `NotFoundException` if the genre does not exist.
- **Update Method**: Updates an existing genre or throws a `NotFoundException` if the genre is not found.
- **Remove Method**: Deletes a genre by ID, with error handling for non-existing genres.

### Error Handling

- **NotFoundException**: Added to provide clear error messages when a genre is not found in the database.

